### PR TITLE
chore: update fast-csv dependency to version 5.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "git@github.com:getnuvo/exceljs.git"
   },
   "engines": {
-    "node": ">=8.3.0"
+    "node": ">=16.0.0"
   },
   "main": "./excel.js",
   "browser": "./dist/exceljs.min.js",
@@ -74,7 +74,7 @@
   "dependencies": {
     "archiver": "^5.0.0",
     "dayjs": "^1.8.34",
-    "fast-csv": "^4.3.1",
+    "fast-csv": "^5.0.5",
     "jszip": "^3.10.1",
     "readable-stream": "^3.6.0",
     "saxes": "^5.0.1",


### PR DESCRIPTION
fast-csv has been updated from ^4.3.1 to 5.0.5. The API used in the codebase (fastCsv.parse() and fastCsv.format()) remains compatible with v5, so no code changes were needed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated `fast-csv` from ^4.3.1 to ^5.0.5 and raised the minimum Node version to >=16. No code changes; our use of `fast-csv.parse()` and `fast-csv.format()` remains compatible.

<sup>Written for commit f713046175ed89f67ffc9b24a764477a0739d335. Summary will update on new commits. <a href="https://cubic.dev/pr/getnuvo/exceljs/pull/10?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214079475073347