### PR TITLE
feat(build): add module and exports fields for modern bundler compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
       "import": "./dist/exceljs.bare.js",
       "require": "./excel.js",
       "default": "./excel.js"
-    }
+    },
+    "./dist/*": "./dist/*",
+    "./lib/*": "./lib/*"
   },
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuvo-exceljs",
-  "version": "4.5.18",
+  "version": "4.5.24",
   "description": "Excel Workbook Manager - Read and Write xlsx and csv Files.",
   "private": false,
   "license": "MIT",
@@ -16,8 +16,18 @@
     "node": ">=16.0.0"
   },
   "main": "./excel.js",
+  "module": "./dist/exceljs.min.js",
   "browser": "./dist/exceljs.min.js",
   "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "browser": "./dist/exceljs.min.js",
+      "import": "./dist/exceljs.bare.js",
+      "require": "./excel.js",
+      "default": "./excel.js"
+    }
+  },
   "files": [
     "dist",
     "lib",


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

## Related to source code (for typings update)

<!-- List with permalink into source code to prove that changes are true -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `module` and an `exports` map to `nuvo-exceljs` for better compatibility with modern bundlers and ESM/CJS resolution while preserving Node `require`.

- **New Features**
  - Added `module: ./dist/exceljs.min.js` and an `exports` map exposing ESM (`import` -> `./dist/exceljs.bare.js`), CJS (`require`/`default` -> `./excel.js`), browser (`./dist/exceljs.min.js`), and `types` (`./index.d.ts`).
  - Added subpath exports for `./dist/*` and `./lib/*` to support deep imports.
  - Kept `main: ./excel.js` and `browser: ./dist/exceljs.min.js`; bumped version to `4.5.24`.

<sup>Written for commit 4df7b15a70065fed07144c22a08e94920bcf93cb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

